### PR TITLE
Better handle time point creation from seconds

### DIFF
--- a/src/time/time_point.rs
+++ b/src/time/time_point.rs
@@ -13,9 +13,15 @@ impl TimePoint {
     }
 
     /// Create a `TimePoint` from seconds
+    ///
+    /// # Panics
+    ///
+    /// Will panics if the `seconds` value fill as parameter is to big to be store as
+    /// millisecond in a i64.
     #[must_use]
     pub fn from_secs(seconds: f64) -> Self {
-        Self((seconds * 1000.0) as i64)
+        let msecs = cast::i64(seconds * 1000.0).unwrap();
+        Self(msecs)
     }
 
     /// Convert to seconds

--- a/src/time/time_point.rs
+++ b/src/time/time_point.rs
@@ -107,4 +107,11 @@ mod tests {
         const TIME: f64 = 624.87;
         assert_eq!(TimePoint::from_secs(TIME).secs(), 624);
     }
+
+    #[test]
+    fn to_big_seconds() {
+        const TIME: f64 = 9_223_372_036_854_775.808; // i64::MAX + 1 as f64 / 1000
+        let result = std::panic::catch_unwind(|| TimePoint::from_secs(TIME));
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
This fix #4 , test `time_point_creation` than can failed on i386 architecture

It's also add a test for to big value for seconds parameter.