### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0](https://github.com/gwen-lg/subtile/compare/v0.1.9...v0.2.0) - 2024-07-18
+
+### Added
+- *(image)* add trait ToImage for ImageBuffer generation
+- *(vobsub)* add genericity to `VobSubParser`
+- *(vobsub)* add a `VobSubDecoder` impl to keep only the TimeSpan
+- *(image)* add trait ToOcrImage and struct ToOcrImageOpt.
+- *(image)* add trait ImageArea and impl for ImageSize types
+- *(image)* add ImageSize trait and use it for VobSubIndexedImage
+- *(vobsub)* move image data from Subtile struct in a dedicated
+- *(vobsub)* add VobSubDecoder trait and use it ...
+- *(vobsub)* [**breaking**] create VobsubParser struct
+- add Default impl (derive) for time structs
+
+### Other
+- add release-plz github workflow
+- *(vobsub)* remove useless `to_image` from VobSubIndexedImage
+- *(vobsub)* use `VobSubToImage` in vobsub example
+- *(vobsub)* create `VobSubToImage` struct who implement ToImage
+- *(vobsub)* add a test to parse only subtitles times
+- *(vobsub)* [**breaking**] remove Subtitle struct,
+- *(vobsub)* invert order of palette and alpha value after parsing
+- *(vobsub)* add VobSubOcrImage to create image addapted to OCR
+- *(vobsub)* add VobSubRleImage to be used by VobSub decoders
+- *(vobsub)* add struct VobSubRleImageData to ...
+- *(vobsub)* create a dedicated method for sub packet reading
+- *(vobsub)* move missing end_time out of iterator
+- some typo fixes and backticks added
+- make dump_images accept iterator of value
+- remove some useless use of cast
+- [**breaking**] rename SubError to SubtileError
+- Add Changelog file with only header

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "subtile"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "cast",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subtile"
-version = "0.1.9"
+version = "0.2.0"
 edition = "2021"
 description = "A crate of utils to operate traitements on subtitles"
 repository = "https://github.com/gwen-lg/subtile"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # subtile
-## Current version: 0.1.9
+## Current version: 0.2.0
 
 ![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
 [![crates.io](https://img.shields.io/crates/v/subtile.svg)](https://crates.io/crates/subtile)
 [![docs.rs](https://docs.rs/subtile/badge.svg)](https://docs.rs/subtile/)
-[![dependency status](https://deps.rs/crate/subtile/0.1.9/status.svg)](https://deps.rs/crate/subtile/0.1.9)
+[![dependency status](https://deps.rs/crate/subtile/0.2.0/status.svg)](https://deps.rs/crate/subtile/0.2.0)
 
 `subtile` is a Rust library which aims to propose a set of operations
 for working on subtitles. Example: parsing from and export in different formats,


### PR DESCRIPTION
## 🤖 New release
* `subtile`: 0.1.9 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/gwen-lg/subtile/compare/v0.1.9...v0.2.0) - 2024-07-18

### Added
- *(image)* add trait ToImage for ImageBuffer generation
- *(vobsub)* add genericity to `VobSubParser`
- *(vobsub)* add a `VobSubDecoder` impl to keep only the TimeSpan
- *(image)* add trait ToOcrImage and struct ToOcrImageOpt.
- *(image)* add trait ImageArea and impl for ImageSize types
- *(image)* add ImageSize trait and use it for VobSubIndexedImage
- *(vobsub)* move image data from Subtile struct in a dedicated
- *(vobsub)* add VobSubDecoder trait and use it ...
- *(vobsub)* [**breaking**] create VobsubParser struct
- add Default impl (derive) for time structs

### Other
- add release-plz github workflow
- *(vobsub)* remove useless `to_image` from VobSubIndexedImage
- *(vobsub)* use `VobSubToImage` in vobsub example
- *(vobsub)* create `VobSubToImage` struct who implement ToImage
- *(vobsub)* add a test to parse only subtitles times
- *(vobsub)* [**breaking**] remove Subtitle struct,
- *(vobsub)* invert order of palette and alpha value after parsing
- *(vobsub)* add VobSubOcrImage to create image addapted to OCR
- *(vobsub)* add VobSubRleImage to be used by VobSub decoders
- *(vobsub)* add struct VobSubRleImageData to ...
- *(vobsub)* create a dedicated method for sub packet reading
- *(vobsub)* move missing end_time out of iterator
- some typo fixes and backticks added
- make dump_images accept iterator of value
- remove some useless use of cast
- [**breaking**] rename SubError to SubtileError
- Add Changelog file with only header
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).