### PR TITLE
chore: release v0.3.1

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -27,5 +27,19 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Install cargo-readme
         run: cargo install cargo-readme
-      - name: Run Cargo readme
-        run: cargo readme > README.md
+      - name: Update README with cargo-readme in the release PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.release-plz.outputs.pr }}
+        run: |
+          set -e
+
+          pr_number=${{ steps.release-plz.outputs.pr && fromJSON(steps.release-plz.outputs.pr).number }}
+          if [[ -n "$pr_number" ]]; then
+            gh pr checkout $pr_number
+            # change "echo" with your commands
+            cargo readme > README.md
+            git add .
+            git commit --amend
+            git push
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/gwen-lg/subtile/compare/v0.3.0...v0.3.1) - 2024-08-19
+
+### Fixed
+- fixup! ci: add cargo readme management in release-plz workflow
+
+### Other
+- test change in lib.rs to see cargo readme run
+- setup current branch for trigger release plz
+- add cargo readme management in release-plz workflow
+
 ## [0.3.0](https://github.com/gwen-lg/subtile/compare/v0.2.0...v0.3.0) - 2024-08-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "subtile"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cast",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subtile"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "A crate of utils to operate traitements on subtitles"
 repository = "https://github.com/gwen-lg/subtile"


### PR DESCRIPTION
## 🤖 New release
* `subtile`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/gwen-lg/subtile/compare/v0.3.0...v0.3.1) - 2024-08-19

### Fixed
- fixup! ci: add cargo readme management in release-plz workflow

### Other
- test change in lib.rs to see cargo readme run
- setup current branch for trigger release plz
- add cargo readme management in release-plz workflow
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).