### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/gwen-lg/subtile/compare/v0.3.0...v0.3.1) - 2025-01-06
+
+### Fixed
+
+- setup a default palette if missing in index file
+- *(const)* add missing const keyword
+
+### Other
+
+- use secrets.GITHUB_TOKEN not RELEASE_PLZ_TOKENT
+- remove useless intermediate variable in `read_palette`
+- add const for `palette` key
+- fix wokflows file path for triggering
+- *(clippy)* remove unnecessary closure for error creation
+- *(clippy)* remove explicit lifetimes than could be elided
+- *(cargo)* update crate thiserror to 2.0
+- *(cargo)* update dependendies
+- include cargo readme management in release-plz workflow
+
 ## [0.3.0](https://github.com/gwen-lg/subtile/compare/v0.2.0...v0.3.0) - 2024-08-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "subtile"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cast",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subtile"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "A crate of utils to operate traitements on subtitles"
 repository = "https://github.com/gwen-lg/subtile"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # subtile
-## Current version: 0.3.0
+## Current version: 0.3.1
 
 ![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
 [![crates.io](https://img.shields.io/crates/v/subtile.svg)](https://crates.io/crates/subtile)
 [![docs.rs](https://docs.rs/subtile/badge.svg)](https://docs.rs/subtile/)
-[![dependency status](https://deps.rs/crate/subtile/0.3.0/status.svg)](https://deps.rs/crate/subtile/0.3.0)
+[![dependency status](https://deps.rs/crate/subtile/0.3.1/status.svg)](https://deps.rs/crate/subtile/0.3.1)
 
 `subtile` is a Rust library which aims to propose a set of operations
 for working on subtitles. Example: parsing from and export in different formats,


### PR DESCRIPTION
## 🤖 New release
* `subtile`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/gwen-lg/subtile/compare/v0.3.0...v0.3.1) - 2025-01-06

### Fixed

- setup a default palette if missing in index file
- *(const)* add missing const keyword

### Other

- use secrets.GITHUB_TOKEN not RELEASE_PLZ_TOKENT
- remove useless intermediate variable in `read_palette`
- add const for `palette` key
- fix wokflows file path for triggering
- *(clippy)* remove unnecessary closure for error creation
- *(clippy)* remove explicit lifetimes than could be elided
- *(cargo)* update crate thiserror to 2.0
- *(cargo)* update dependendies
- include cargo readme management in release-plz workflow
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).