### PR TITLE
chore: release v0.3.2

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,4 +1,4 @@
-name: Release Plz
+name: Release-plz
 
 permissions:
   pull-requests: write
@@ -10,27 +10,51 @@ on:
       - main
 
 jobs:
-  release-plz:
-    name: Release-plz
+  release-plz-release:
+    name: Release-plz release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
-        id: release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: release-plz/action@v0.5
+        with:
+          command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Install cargo-readme
         run: cargo install cargo-readme
       - name: Update README with cargo-readme in the release PR
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           PR: ${{ steps.release-plz.outputs.pr }}
         run: |
           set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/gwen-lg/subtile/compare/v0.3.1...v0.3.2) - 2025-01-12
+
+### Added
+
+- *(ods)* manage object data split in multiple segment
+
+### Fixed
+
+- *(pgs)* skip_segment content in DecodeTimeOnly
+
+### Other
+
+- *(release-plz)* update github action from v0.3.112
+- *(ods)* create read_object_data function
+- *(ods)* move ObjectDataLength reading in dedicated function
+- *(ods)* move image size fields reading in a dedicated function
+- *(ods)* move last_in_sequence_flag field handling into a method
+- *(ods)* move object fields handling into a function
+- *(pgs)* add only_one.sup fixtures and associate test
+
 ## [0.3.1](https://github.com/gwen-lg/subtile/compare/v0.3.0...v0.3.1) - 2025-01-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "subtile"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "cast",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subtile"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "A crate of utils to operate traitements on subtitles"
 repository = "https://github.com/gwen-lg/subtile"


### PR DESCRIPTION
## 🤖 New release
* `subtile`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/gwen-lg/subtile/compare/v0.3.1...v0.3.2) - 2025-01-12

### Added

- *(ods)* manage object data split in multiple segment

### Fixed

- *(pgs)* skip_segment content in DecodeTimeOnly

### Other

- *(release-plz)* update github action from v0.3.112
- *(ods)* create read_object_data function
- *(ods)* move ObjectDataLength reading in dedicated function
- *(ods)* move image size fields reading in a dedicated function
- *(ods)* move last_in_sequence_flag field handling into a method
- *(ods)* move object fields handling into a function
- *(pgs)* add only_one.sup fixtures and associate test
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).