### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/gwen-lg/subtile/compare/v0.3.1...v0.3.2) - 2025-01-12
+
+### Added
+
+- *(ods)* manage object data split in multiple segment
+
+### Fixed
+
+- *(pgs)* skip_segment content in DecodeTimeOnly
+
+### Other
+
+- *(release-plz)* update github action from v0.3.112
+- *(ods)* create read_object_data function
+- *(ods)* move ObjectDataLength reading in dedicated function
+- *(ods)* move image size fields reading in a dedicated function
+- *(ods)* move last_in_sequence_flag field handling into a method
+- *(ods)* move object fields handling into a function
+- *(pgs)* add only_one.sup fixtures and associate test
+
 ## [0.3.1](https://github.com/gwen-lg/subtile/compare/v0.3.0...v0.3.1) - 2025-01-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "subtile"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "cast",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subtile"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "A crate of utils to operate traitements on subtitles"
 repository = "https://github.com/gwen-lg/subtile"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # subtile
-## Current version: 0.3.1
+## Current version: 0.3.2
 
 ![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
 [![crates.io](https://img.shields.io/crates/v/subtile.svg)](https://crates.io/crates/subtile)
 [![docs.rs](https://docs.rs/subtile/badge.svg)](https://docs.rs/subtile/)
-[![dependency status](https://deps.rs/crate/subtile/0.3.1/status.svg)](https://deps.rs/crate/subtile/0.3.1)
+[![dependency status](https://deps.rs/crate/subtile/0.3.2/status.svg)](https://deps.rs/crate/subtile/0.3.2)
 
 `subtile` is a Rust library which aims to propose a set of operations
 for working on subtitles. Example: parsing from and export in different formats,


### PR DESCRIPTION
## 🤖 New release
* `subtile`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/gwen-lg/subtile/compare/v0.3.1...v0.3.2) - 2025-01-12

### Added

- *(ods)* manage object data split in multiple segment

### Fixed

- *(pgs)* skip_segment content in DecodeTimeOnly

### Other

- *(release-plz)* update github action from v0.3.112
- *(ods)* create read_object_data function
- *(ods)* move ObjectDataLength reading in dedicated function
- *(ods)* move image size fields reading in a dedicated function
- *(ods)* move last_in_sequence_flag field handling into a method
- *(ods)* move object fields handling into a function
- *(pgs)* add only_one.sup fixtures and associate test
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).