### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/gwen-lg/subtile/compare/v0.3.2...v0.4.0) - 2025-04-15
+
+### Added
+
+- *(vobsub)* add lang parsing in Index file
+- *(vobsub)* [**breaking**] make Index optional.
+- *(vobsub)* add TimePointIdx to implement Display
+- *(time)* set msecs public
+- *(webvtt)* add write_line public function
+- *(time)* add TimePointVtt to handle display of time for WebVTT
+- *(time)* add TimePointSrt to implement display on TimePoint
+- implement FusedIterator for SubParser & VobsubParser
+
+### Fixed
+
+- *(image)* re-export GrayImage & Luma from image crate
+
+### Other
+
+- *(srt)* add write_line in srt module
+- *(release-plz)* update release-plz action
+- *(release-plz)* disable `release-plz` workflow for fork
+- add dependabot.yml for github
+- use LazyLock from std instead of OnceCell
+- *(clippy)* enable additional lints
+- *(clippy)* add missing semicolon to the last statement
+- *(vobsub)* Use Luma<u8> from image for palette.
+- *(decoder)* rework decoder loop to handle parsing errors cleaner
+- *(pgs)* rename `seg_header` var in `DecodeTimeImage`
+- *(clippy)* directly use variables in the `format!` string
+- *(cargo)* run cargo update
+- *(clippy)* add parenthesis on mixed usage of arithmetic and bit shifting/combining operators
+- *(lint)* allow for clippy lint `missing_const_for_fn` invalide report
+- *(github)* add FUNDING.yml file with liberapay account
+- *(commits)* add check-commits on push
+- *(commits)* add workflow to check individual commits
+- *(code_check)* use locked flag for reduce time
+- *(code_check)* add rust-cache action
+- *(code_check)* reorder steps with typos/fmt at first.
+
 ## [0.3.2](https://github.com/gwen-lg/subtile/compare/v0.3.1...v0.3.2) - 2025-01-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtile"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "cast",
  "compact_str",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +117,20 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "crc32fast"
@@ -189,6 +212,12 @@ name = "iter_fixed"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "592ff74cdc6a923b2ae357dad7db2f5dcbf5d4ace9afcf3ab7c7f20b209fd949"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
@@ -362,6 +391,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,10 +429,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "subtile"
 version = "0.3.2"
 dependencies = [
  "cast",
+ "compact_str",
  "env_logger",
  "glob",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subtile"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "A crate of utils to operate traitements on subtitles"
 repository = "https://github.com/gwen-lg/subtile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 cast = "0.3"
+compact_str = "0.9.0"
 image = { version = "0.25", default-features = false, features = ["png"] }
 iter_fixed = "0.4"
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # subtile
-## Current version: 0.3.2
+## Current version: 0.4.0
 
 ![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
 [![crates.io](https://img.shields.io/crates/v/subtile.svg)](https://crates.io/crates/subtile)
 [![docs.rs](https://docs.rs/subtile/badge.svg)](https://docs.rs/subtile/)
-[![dependency status](https://deps.rs/crate/subtile/0.3.2/status.svg)](https://deps.rs/crate/subtile/0.3.2)
+[![dependency status](https://deps.rs/crate/subtile/0.4.0/status.svg)](https://deps.rs/crate/subtile/0.4.0)
 
 `subtile` is a Rust library which aims to propose a set of operations
 for working on subtitles. Example: parsing from and export in different formats,

--- a/src/vobsub/idx.rs
+++ b/src/vobsub/idx.rs
@@ -3,18 +3,34 @@
 use log::trace;
 use regex::Regex;
 use std::{
-    fs,
+    fmt, fs,
     io::{self, prelude::*, BufReader},
     path::Path,
     sync::LazyLock,
 };
 
-use crate::vobsub::IResultExt;
+use crate::{time::TimePoint, vobsub::IResultExt};
 
 use super::{
     palette::{palette, DEFAULT_PALETTE},
     sub, Palette, VobSubError,
 };
+
+/// Extend `TimePoint` to implement `idx` specific `Display`.
+#[repr(transparent)]
+pub struct TimePointIdx(TimePoint);
+
+impl From<TimePoint> for TimePointIdx {
+    fn from(value: TimePoint) -> Self {
+        Self(value)
+    }
+}
+
+impl fmt::Display for TimePointIdx {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt_separator(f, ':')
+    }
+}
 
 /// A `*.idx` file describing the subtitles in a `*.sub` file.
 #[derive(Debug)]

--- a/src/vobsub/idx.rs
+++ b/src/vobsub/idx.rs
@@ -1,5 +1,6 @@
 //! Parse a file in `*.idx` format.
 
+use compact_str::CompactString;
 use log::trace;
 use regex::Regex;
 use std::{
@@ -9,12 +10,37 @@ use std::{
     sync::LazyLock,
 };
 
-use crate::{time::TimePoint, vobsub::IResultExt};
-
 use super::{
     palette::{palette, DEFAULT_PALETTE},
     Palette, VobSubError,
 };
+use crate::{time::TimePoint, vobsub::IResultExt};
+
+/// Lang of a subtitle as reported in `VobSub` idx file.
+#[derive(Debug, Clone)]
+pub struct Lang(CompactString);
+
+impl Lang {
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn lang(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<&str> for Lang {
+    type Error = VobSubError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        static KEY_VALUE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new("^([a-z]+), index: (.*)").unwrap());
+        if let Some(cap) = KEY_VALUE.captures(value) {
+            let lang = cap.get(1).unwrap().as_str();
+            Ok(Self(lang.into()))
+        } else {
+            Err(VobSubError::LangParsing)
+        }
+    }
+}
 
 /// Extend `TimePoint` to implement `idx` specific `Display`.
 #[repr(transparent)]
@@ -39,9 +65,12 @@ pub struct Index {
     //size: Size,
     /// The colors used for the subtitles.
     palette: Palette,
+    /// Lang of the subtitles
+    lang: Option<Lang>,
 }
 
 const PALETTE_KEY: &str = "palette";
+const LANG_KEY: &str = "id";
 
 impl Index {
     /// Open an `*.idx` file and the associated `*.sub` file.
@@ -58,21 +87,65 @@ impl Index {
 
         let f = fs::File::open(path).map_err(mkerr_idx)?;
         let input = io::BufReader::new(f);
-        let palette = read_palette(input, &mkerr_idx).or_else(|err| {
-            if let VobSubError::MissingKey(PALETTE_KEY) = err {
-                Ok(DEFAULT_PALETTE)
-            } else {
-                Err(err)
-            }
-        })?;
+        Self::read_index(input, &mkerr_idx)
+    }
 
-        Ok(Self { palette })
+    /// Read the palette in `*.idx` file content
+    ///
+    /// # Errors
+    /// Will return `VobSubError::MissingKey` if the palette key/value is not present
+    /// Will return `VobSubError::PaletteError` if failed to read and parse palette value.
+    ///
+    /// # Panics
+    /// Panic if the Regex creation failed
+    #[profiling::function]
+    pub fn read_index<T, Err>(mut input: BufReader<T>, mkerr: &Err) -> Result<Self, VobSubError>
+    where
+        T: std::io::Read,
+        Err: Fn(io::Error) -> VobSubError,
+    {
+        static KEY_VALUE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new("^([A-Za-z/ ]+): (.*)").unwrap());
+
+        let mut palette_val = None;
+        let mut lang = None;
+        let mut buf = String::with_capacity(256);
+        while input.read_line(&mut buf).map_err(mkerr)? > 0 {
+            let line = buf.trim_end();
+            if let Some(cap) = KEY_VALUE.captures(line) {
+                let key = cap.get(1).unwrap().as_str();
+                let val = cap.get(2).unwrap().as_str();
+                match key {
+                    PALETTE_KEY => {
+                        palette_val = Some(
+                            palette(val.as_bytes())
+                                .to_result_no_rest()
+                                .map_err(VobSubError::PaletteError)?,
+                        );
+                    }
+                    LANG_KEY => {
+                        //TODO: reporte missing lang ?
+                        lang = Lang::try_from(val).ok();
+                    }
+                    _ => trace!("Unimplemented idx key: {key}"),
+                }
+            }
+            buf.clear();
+        }
+
+        //TODO: report missing palette ?
+        let palette = match palette_val {
+            Some(palette) => palette,
+            None => DEFAULT_PALETTE,
+        };
+
+        Ok(Self { palette, lang })
     }
 
     /// Create an Index from a palette and sub data
     #[must_use]
-    pub const fn init(palette: Palette) -> Self {
-        Self { palette }
+    pub const fn init(palette: Palette, lang: Option<Lang>) -> Self {
+        Self { palette, lang }
     }
 
     /// Get the palette associated with this `*.idx` file.
@@ -80,47 +153,11 @@ impl Index {
     pub const fn palette(&self) -> &Palette {
         &self.palette
     }
-}
-
-/// Read the palette in `*.idx` file content
-///
-/// # Errors
-/// Will return `VobSubError::MissingKey` if the palette key/value is not present
-/// Will return `VobSubError::PaletteError` if failed to read and parse palette value.
-///
-/// # Panics
-/// Panic if the Regex creation failed
-#[profiling::function]
-pub fn read_palette<T, Err>(mut input: BufReader<T>, mkerr: &Err) -> Result<Palette, VobSubError>
-where
-    T: std::io::Read,
-    Err: Fn(io::Error) -> VobSubError,
-{
-    static KEY_VALUE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new("^([A-Za-z/ ]+): (.*)").unwrap());
-
-    let mut palette_val: Option<Palette> = None;
-    let mut buf = String::with_capacity(256);
-    while input.read_line(&mut buf).map_err(mkerr)? > 0 {
-        let line = buf.trim_end();
-        if let Some(cap) = KEY_VALUE.captures(line) {
-            let key = cap.get(1).unwrap().as_str();
-            let val = cap.get(2).unwrap().as_str();
-            match key {
-                PALETTE_KEY => {
-                    palette_val = Some(
-                        palette(val.as_bytes())
-                            .to_result_no_rest()
-                            .map_err(VobSubError::PaletteError)?,
-                    );
-                }
-                _ => trace!("Unimplemented idx key: {key}"),
-            }
-        }
-        buf.clear();
+    /// Get the lang associated with this `*.idx` file.
+    #[must_use]
+    pub const fn lang(&self) -> &Option<Lang> {
+        &self.lang
     }
-
-    palette_val.ok_or(VobSubError::MissingKey(PALETTE_KEY))
 }
 
 #[cfg(test)]

--- a/src/vobsub/idx.rs
+++ b/src/vobsub/idx.rs
@@ -13,7 +13,7 @@ use crate::{time::TimePoint, vobsub::IResultExt};
 
 use super::{
     palette::{palette, DEFAULT_PALETTE},
-    sub, Palette, VobSubError,
+    Palette, VobSubError,
 };
 
 /// Extend `TimePoint` to implement `idx` specific `Display`.
@@ -39,8 +39,6 @@ pub struct Index {
     //size: Size,
     /// The colors used for the subtitles.
     palette: Palette,
-    /// Our compressed subtitle data.
-    sub_data: Vec<u8>,
 }
 
 const PALETTE_KEY: &str = "palette";
@@ -68,41 +66,19 @@ impl Index {
             }
         })?;
 
-        let mut sub_path = path.to_owned();
-        sub_path.set_extension("sub");
-
-        let sub_path = sub_path.as_path();
-        let mut sub = fs::File::open(sub_path).map_err(|source| VobSubError::Io {
-            source,
-            path: sub_path.into(),
-        })?;
-        let mut sub_data = vec![];
-        sub.read_to_end(&mut sub_data)
-            .map_err(|source| VobSubError::Io {
-                source,
-                path: sub_path.into(),
-            })?;
-
-        Ok(Self { palette, sub_data })
+        Ok(Self { palette })
     }
 
     /// Create an Index from a palette and sub data
     #[must_use]
-    pub const fn init(palette: Palette, sub_data: Vec<u8>) -> Self {
-        Self { palette, sub_data }
+    pub const fn init(palette: Palette) -> Self {
+        Self { palette }
     }
 
     /// Get the palette associated with this `*.idx` file.
     #[must_use]
     pub const fn palette(&self) -> &Palette {
         &self.palette
-    }
-
-    /// Iterate over the subtitles associated with this `*.idx` file.
-    #[must_use]
-    #[allow(clippy::missing_const_for_fn)]
-    pub fn subtitles<D>(&self) -> sub::VobsubParser<D> {
-        sub::VobsubParser::new(&self.sub_data)
     }
 }
 

--- a/src/vobsub/mod.rs
+++ b/src/vobsub/mod.rs
@@ -76,7 +76,7 @@ mod probe;
 mod sub;
 
 pub use self::{
-    idx::{read_palette, Index},
+    idx::Index,
     img::{conv_to_rgba, VobSubIndexedImage, VobSubOcrImage, VobSubToImage},
     palette::{palette, palette_rgb_to_luminance, Palette},
     probe::{is_idx_file, is_sub_file},
@@ -98,6 +98,10 @@ pub enum VobSubError {
     /// We were unable to find a required key in an `*.idx` file.
     #[error("Could not find required key '{0}'")]
     MissingKey(&'static str),
+
+    /// The lang value failed to be parsed
+    #[error("Failed to parse lang in idx file")]
+    LangParsing,
 
     /// We could not parse a value.
     #[error("Could not parse: {0}")]

--- a/src/vobsub/mod.rs
+++ b/src/vobsub/mod.rs
@@ -15,10 +15,11 @@
 //! };
 //!
 //! let idx = subtile::vobsub::Index::open("./fixtures/example.idx").unwrap();
-//! for sub in idx.subtitles::<(TimeSpan, VobSubIndexedImage)>() {
+//! let sub = subtile::vobsub::Sub::open("./fixtures/example.sub").unwrap();
+//! for sub in sub.subtitles::<(TimeSpan, VobSubIndexedImage)>() {
 //!     let (time_span, image) = sub.unwrap();
 //!     println!("Time: {:0.3?}-{:0.3?}", time_span.start, time_span.end);
-//!     //println!("Always show: {:?}", sub.force());
+//!     //println!("Always show: {:?}", subs.force());
 //!     let area = image.area();
 //!     println!("At: {}, {}", area.left(), area.top());
 //!     println!("Size: {}x{}", image.width(), image.height());
@@ -79,7 +80,7 @@ pub use self::{
     img::{conv_to_rgba, VobSubIndexedImage, VobSubOcrImage, VobSubToImage},
     palette::{palette, palette_rgb_to_luminance, Palette},
     probe::{is_idx_file, is_sub_file},
-    sub::ErrorMissing,
+    sub::{ErrorMissing, Sub},
 };
 
 use crate::content::ContentError;


### PR DESCRIPTION



## 🤖 New release

* `subtile`: 0.3.2 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `subtile` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant VobSubError:LangParsing in /tmp/.tmp2BE2XL/subtile/src/vobsub/mod.rs:104

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/function_missing.ron

Failed in:
  function subtile::vobsub::read_palette, previously in file /tmp/.tmpJ905lq/subtile/src/vobsub/idx.rs:100

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/inherent_method_missing.ron

Failed in:
  Index::subtitles, previously in file /tmp/.tmpJ905lq/subtile/src/vobsub/idx.rs:87
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/gwen-lg/subtile/compare/v0.3.2...v0.4.0) - 2025-04-15

### Added

- *(vobsub)* add lang parsing in Index file
- *(vobsub)* [**breaking**] make Index optional.
- *(vobsub)* add TimePointIdx to implement Display
- *(time)* set msecs public
- *(webvtt)* add write_line public function
- *(time)* add TimePointVtt to handle display of time for WebVTT
- *(time)* add TimePointSrt to implement display on TimePoint
- implement FusedIterator for SubParser & VobsubParser

### Fixed

- *(image)* re-export GrayImage & Luma from image crate

### Other

- *(srt)* add write_line in srt module
- *(release-plz)* update release-plz action
- *(release-plz)* disable `release-plz` workflow for fork
- add dependabot.yml for github
- use LazyLock from std instead of OnceCell
- *(clippy)* enable additional lints
- *(clippy)* add missing semicolon to the last statement
- *(vobsub)* Use Luma<u8> from image for palette.
- *(decoder)* rework decoder loop to handle parsing errors cleaner
- *(pgs)* rename `seg_header` var in `DecodeTimeImage`
- *(clippy)* directly use variables in the `format!` string
- *(cargo)* run cargo update
- *(clippy)* add parenthesis on mixed usage of arithmetic and bit shifting/combining operators
- *(lint)* allow for clippy lint `missing_const_for_fn` invalide report
- *(github)* add FUNDING.yml file with liberapay account
- *(commits)* add check-commits on push
- *(commits)* add workflow to check individual commits
- *(code_check)* use locked flag for reduce time
- *(code_check)* add rust-cache action
- *(code_check)* reorder steps with typos/fmt at first.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).