### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/gwen-lg/subtile/compare/v0.3.2...v0.4.0) - 2025-07-22
+
+### Added
+
+- *(clippy)* enable additionnal lints for crate
+- *(taplo)* add Taplo configuration file
+- *(vobsub)* add lang parsing in Index file
+- *(vobsub)* [**breaking**] make Index optional.
+- *(vobsub)* add TimePointIdx to implement Display
+- *(time)* set msecs public
+- *(webvtt)* add write_line public function
+- *(time)* add TimePointVtt to handle display of time for WebVTT
+- *(time)* add TimePointSrt to implement display on TimePoint
+- implement FusedIterator for SubParser & VobsubParser
+
+### Fixed
+
+- *(error)* add `#[non_exhaustive]` on pub error
+- *(error)* add `#[non_exhaustive]` on pub error
+- replace cast of `usize` to `i64` by `try_from`
+- *(error)* remove useless display of parent error
+- *(workflow)* remove invalid strategy in code_check
+- *(workflow)* add missing commit ref for checkout step
+- *(image)* re-export GrayImage & Luma from image crate
+
+### Other
+
+- *(error)* remove capital letter at start of error message
+- cargo update for dependencies
+- *(error)* remove capital letter at start of error message
+- *(pgs)* remove unncessary semicolon
+- *(clippy)* enable lint used_underscore_binding
+- *(commits)* disable check of `wip*` branches
+- *(commits)* avoid too long concurrency group name
+- *(taplo)* add check formating of Cargo.toml
+- *(cargo)* fmt of Cargo.toml with reorder_keys
+- *(release)* use publishing environment in release workflow
+- *(release)* add rust-cache on release-plz PR update
+- *(release)* move install of cargo-readme before release-plz action
+- *(release)* update release-plz workflow
+- *(workflow)* correct yaml style
+- *(check)* don't run workflow on 'wip' branches
+- *(checks)* remove custom run-name
+- move rust-cache before install cargo-readme
+- cancel running workflow on branch update
+- migrate `vobsub` parsing to nom 8.0
+- *(vobsub)* tag_bytes alias instead of full path
+- use enum ControlCommandTag for named control command tag
+- *(srt)* add write_line in srt module
+- *(release-plz)* update release-plz action
+- *(release-plz)* disable `release-plz` workflow for fork
+- add dependabot.yml for github
+- use LazyLock from std instead of OnceCell
+- *(clippy)* enable additional lints
+- *(clippy)* add missing semicolon to the last statement
+- *(vobsub)* Use Luma<u8> from image for palette.
+- *(decoder)* rework decoder loop to handle parsing errors cleaner
+- *(pgs)* rename `seg_header` var in `DecodeTimeImage`
+- *(clippy)* directly use variables in the `format!` string
+- *(cargo)* run cargo update
+- *(clippy)* add parenthesis on mixed usage of arithmetic and bit shifting/combining operators
+- *(lint)* allow for clippy lint `missing_const_for_fn` invalide report
+- *(github)* add FUNDING.yml file with liberapay account
+- *(commits)* add check-commits on push
+- *(commits)* add workflow to check individual commits
+- *(code_check)* use locked flag for reduce time
+- *(code_check)* add rust-cache action
+- *(code_check)* reorder steps with typos/fmt at first.
+
 ## [0.3.2](https://github.com/gwen-lg/subtile/compare/v0.3.1...v0.3.2) - 2025-01-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtile"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "cast",
  "compact_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subtile"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "A crate of utils to operate traitements on subtitles"
 repository = "https://github.com/gwen-lg/subtile"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # subtile
-## Current version: 0.3.2
+## Current version: 0.4.0
 
 ![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
 [![crates.io](https://img.shields.io/crates/v/subtile.svg)](https://crates.io/crates/subtile)
 [![docs.rs](https://docs.rs/subtile/badge.svg)](https://docs.rs/subtile/)
-[![dependency status](https://deps.rs/crate/subtile/0.3.2/status.svg)](https://deps.rs/crate/subtile/0.3.2)
+[![dependency status](https://deps.rs/crate/subtile/0.4.0/status.svg)](https://deps.rs/crate/subtile/0.4.0)
 
 `subtile` is a Rust library which aims to propose a set of operations
 for working on subtitles. Example: parsing from and export in different formats,


### PR DESCRIPTION



## 🤖 New release

* `subtile`: 0.3.2 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `subtile` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum SubtileError in /tmp/.tmpBKl3VC/subtile/src/errors.rs:10
  enum ReadError in /tmp/.tmpBKl3VC/subtile/src/pgs/mod.rs:84
  enum ErrorMissing in /tmp/.tmpBKl3VC/subtile/src/vobsub/sub.rs:269
  enum DumpError in /tmp/.tmpBKl3VC/subtile/src/image/utils.rs:15
  enum PgsError in /tmp/.tmpBKl3VC/subtile/src/pgs/mod.rs:29
  enum ContentError in /tmp/.tmpBKl3VC/subtile/src/content/mod.rs:13
  enum VobSubError in /tmp/.tmpBKl3VC/subtile/src/vobsub/mod.rs:94

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_missing.ron

Failed in:
  function subtile::vobsub::read_palette, previously in file /tmp/.tmp857FOZ/subtile/src/vobsub/idx.rs:100

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  Index::subtitles, previously in file /tmp/.tmp857FOZ/subtile/src/vobsub/idx.rs:87
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/gwen-lg/subtile/compare/v0.3.2...v0.4.0) - 2025-07-22

### Added

- *(clippy)* enable additionnal lints for crate
- *(taplo)* add Taplo configuration file
- *(vobsub)* add lang parsing in Index file
- *(vobsub)* [**breaking**] make Index optional.
- *(vobsub)* add TimePointIdx to implement Display
- *(time)* set msecs public
- *(webvtt)* add write_line public function
- *(time)* add TimePointVtt to handle display of time for WebVTT
- *(time)* add TimePointSrt to implement display on TimePoint
- implement FusedIterator for SubParser & VobsubParser

### Fixed

- *(error)* add `#[non_exhaustive]` on pub error
- *(error)* add `#[non_exhaustive]` on pub error
- replace cast of `usize` to `i64` by `try_from`
- *(error)* remove useless display of parent error
- *(workflow)* remove invalid strategy in code_check
- *(workflow)* add missing commit ref for checkout step
- *(image)* re-export GrayImage & Luma from image crate

### Other

- *(error)* remove capital letter at start of error message
- cargo update for dependencies
- *(error)* remove capital letter at start of error message
- *(pgs)* remove unncessary semicolon
- *(clippy)* enable lint used_underscore_binding
- *(commits)* disable check of `wip*` branches
- *(commits)* avoid too long concurrency group name
- *(taplo)* add check formating of Cargo.toml
- *(cargo)* fmt of Cargo.toml with reorder_keys
- *(release)* use publishing environment in release workflow
- *(release)* add rust-cache on release-plz PR update
- *(release)* move install of cargo-readme before release-plz action
- *(release)* update release-plz workflow
- *(workflow)* correct yaml style
- *(check)* don't run workflow on 'wip' branches
- *(checks)* remove custom run-name
- move rust-cache before install cargo-readme
- cancel running workflow on branch update
- migrate `vobsub` parsing to nom 8.0
- *(vobsub)* tag_bytes alias instead of full path
- use enum ControlCommandTag for named control command tag
- *(srt)* add write_line in srt module
- *(release-plz)* update release-plz action
- *(release-plz)* disable `release-plz` workflow for fork
- add dependabot.yml for github
- use LazyLock from std instead of OnceCell
- *(clippy)* enable additional lints
- *(clippy)* add missing semicolon to the last statement
- *(vobsub)* Use Luma<u8> from image for palette.
- *(decoder)* rework decoder loop to handle parsing errors cleaner
- *(pgs)* rename `seg_header` var in `DecodeTimeImage`
- *(clippy)* directly use variables in the `format!` string
- *(cargo)* run cargo update
- *(clippy)* add parenthesis on mixed usage of arithmetic and bit shifting/combining operators
- *(lint)* allow for clippy lint `missing_const_for_fn` invalide report
- *(github)* add FUNDING.yml file with liberapay account
- *(commits)* add check-commits on push
- *(commits)* add workflow to check individual commits
- *(code_check)* use locked flag for reduce time
- *(code_check)* add rust-cache action
- *(code_check)* reorder steps with typos/fmt at first.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).