### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,44 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1](https://github.com/gwen-lg/subtile/compare/v0.4.0...v0.4.1) - 2025-08-10
+
+### Added
+
+- add `iter` fn on `RleEncodedImage`
+
+### Fixed
+
+- replace wildcard match arm in pgs decoding
+- fix invalid lint in Cargo.toml
+- add empty line between srt subtitles
+
+### Other
+
+- enable additionnal clippy lints
+- enable unused_trait_names clippy lint
+- update const value in test to_big_second
+- use `join` instead of `push` fn for just created `PathBuf`
+- use fs::read instead of verbose
+- use `map_or` instead of manual `if let` espression with option
+- enable lint `too_long_first_doc_paragraph`
+- use tuple array convertion instead on manual management
+- declare some lint as `warn` instead of `deny`
+- fix clippy lints ordering in Cargo.toml
+- failed ci check on warning
+- enable `manual-let-else` clippy lint + fix
+- run cargo update to update dependenies
+- *(taplo)* add check lint of Cargo.toml
+- *(taplo)* check toml formating of all toml files in root
+- replace elided lifetime with `'_` where it's confusing
+- add missing missing backticks
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtile"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cast",
  "compact_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subtile"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "A crate of utils to operate traitements on subtitles"
 repository = "https://github.com/gwen-lg/subtile"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # subtile
-## Current version: 0.4.0
+## Current version: 0.4.1
 
 ![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
 [![crates.io](https://img.shields.io/crates/v/subtile.svg)](https://crates.io/crates/subtile)
 [![docs.rs](https://docs.rs/subtile/badge.svg)](https://docs.rs/subtile/)
-[![dependency status](https://deps.rs/crate/subtile/0.4.0/status.svg)](https://deps.rs/crate/subtile/0.4.0)
+[![dependency status](https://deps.rs/crate/subtile/0.4.1/status.svg)](https://deps.rs/crate/subtile/0.4.1)
 
 `subtile` is a Rust library which aims to propose a set of operations
 for working on subtitles. Example: parsing from and export in different formats,


### PR DESCRIPTION



## 🤖 New release

* `subtile`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).