### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/gwen-lg/subtile/compare/v0.4.1...v0.4.2) - 2026-01-17
+
+### Fixed
+
+- typos in error msg `managed'
+
+### Other
+
+- add dependencies check with cargo-machete
+- Add test for continued parsing after seq without ods segment
+- *(toml)* enable arrays/keys reorder for dev-dependencies section
+- update dependencies
+- *(commits)* simplify the commits_check workflow
+- test rework cargo_readme step
+- simplify rust checks and tests job
+- move toml checks and lint in a dedicated job
+- move typos check in is own job.
+- *(deps)* bump actions/checkout from 4 to 6
+- enable `reorder_arrays` for Cargo.toml
+- enable pedantic group
+- update clippy lints setup in Cargo.toml
+- disable some clippy lints related to cast
+- disable lint `struct_excessive_bools` for two structs
+- rename palette prefix in member of Palette struct
+
 ## [0.4.0](https://github.com/gwen-lg/subtile/compare/v0.3.2...v0.4.0) - 2025-07-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtile"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "assert_matches2",
  "cast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subtile"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "A crate of utils to operate traitements on subtitles"
 repository = "https://github.com/gwen-lg/subtile"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # subtile
-## Current version: 0.4.1
+## Current version: 0.4.2
 
 ![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
 [![crates.io](https://img.shields.io/crates/v/subtile.svg)](https://crates.io/crates/subtile)
 [![docs.rs](https://docs.rs/subtile/badge.svg)](https://docs.rs/subtile/)
-[![dependency status](https://deps.rs/crate/subtile/0.4.1/status.svg)](https://deps.rs/crate/subtile/0.4.1)
+[![dependency status](https://deps.rs/crate/subtile/0.4.2/status.svg)](https://deps.rs/crate/subtile/0.4.2)
 
 `subtile` is a Rust library which aims to propose a set of operations
 for working on subtitles. Example: parsing from and export in different formats,


### PR DESCRIPTION



## 🤖 New release

* `subtile`: 0.4.1 -> 0.4.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.4.2](https://github.com/gwen-lg/subtile/compare/v0.4.1...v0.4.2) - 2026-01-17

### Fixed

- typos in error msg `managed'

### Other

- add dependencies check with cargo-machete
- Add test for continued parsing after seq without ods segment
- *(toml)* enable arrays/keys reorder for dev-dependencies section
- update dependencies
- *(commits)* simplify the commits_check workflow
- test rework cargo_readme step
- simplify rust checks and tests job
- move toml checks and lint in a dedicated job
- move typos check in is own job.
- *(deps)* bump actions/checkout from 4 to 6
- enable `reorder_arrays` for Cargo.toml
- enable pedantic group
- update clippy lints setup in Cargo.toml
- disable some clippy lints related to cast
- disable lint `struct_excessive_bools` for two structs
- rename palette prefix in member of Palette struct
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).